### PR TITLE
Update squid.inc TLS force use of TLSv1_2 and TLSv1_3 disallow use of…

### DIFF
--- a/www/pfSense-pkg-squid/files/usr/local/pkg/squid.inc
+++ b/www/pfSense-pkg-squid/files/usr/local/pkg/squid.inc
@@ -1230,7 +1230,7 @@ function squid_resync_general() {
 				$crt_pk = SQUID_CONFBASE . "/serverkey.pem";
 				$crt_capath = SQUID_LOCALBASE . "/share/certs/";
 				$crt_cafile = SQUID_LOCALBASE . "/share/certs/ca-root-nss.crt";
-				$sslproxy_options = "NO_SSLv3";
+				$sslproxy_options = "NO_SSLv3, NO_TLSv1, NO_TLSv1_1";
 				/* XXX: Bug #4453, Bug #6592, Feature #6593, Bug #6563
 				 * http://wiki.squid-cache.org/ConfigExamples/Intercept/SslBumpExplicit#Modern_DH.2FEDH_ciphers_usage
 				 */


### PR DESCRIPTION
… TLS1 and TLS1_1

$sslproxy_options is used with tls_outgoing_options options and should have blocked use of TLS1 and TLS1_1 when doing packet scans without this feature flag set the proxy was allowing connections with TLS1_1 after adding this directive feature flag manually it forced TLSv1_2 and TLSv1_3 to be used as seen in pcap files. Please set this as many websites will send change cipher requests when attempting TLS1_1